### PR TITLE
Add gender drop down

### DIFF
--- a/src/code_systems/loinc.test.ts
+++ b/src/code_systems/loinc.test.ts
@@ -3,18 +3,24 @@
  */
 
 import { getSelectOptions, variantCodes } from "./loinc";
-import { loincCodes } from "./loincCodes";
+import { loincCodes, loincSelect } from "./loincCodes";
 
 describe("LOINC", () => {
   /**
-   * Given that the LOINC valuesets have been persisted to file
-   * When the LOINC api is queried
-   * Then the API results should be the same as the persisted data
+   * Given that the LOINC select options have been created from static file
+   * When the LOINC api is queried and converted to select options
+   * Then the results should be the same
    */
   test("Codes haven't changed", async () => {
     const valueSet = await variantCodes();
+    const selectValues = {
+      classification: getSelectOptions(valueSet.classification),
+      inheritance: getSelectOptions(valueSet.inheritance),
+      zygosity: getSelectOptions(valueSet.zygosity),
+      followUp: getSelectOptions(valueSet.followUp),
+    };
 
-    expect(valueSet).toEqual(loincCodes);
+    expect(selectValues).toEqual(loincSelect);
   });
 
   /**

--- a/src/code_systems/loinc.ts
+++ b/src/code_systems/loinc.ts
@@ -29,7 +29,8 @@ const getValueSetData = async (valueSet: string): Promise<ValueSet> => {
   const response = await fetch(url, requestInit);
 
   if (!response.ok) {
-    throw new Error(`Failed to get loinc ${valueSet}`);
+    console.error(response.body);
+    throw new Error(`Failed to get loinc ${valueSet}, maybe check your loinc credentials in the .env file`);
   }
   return await response.json();
 };

--- a/src/components/reports/ReportForm.test.tsx
+++ b/src/components/reports/ReportForm.test.tsx
@@ -61,7 +61,7 @@ async function setLabAndPatient() {
   });
 
   await act(async () => {
-    clearAndType(screen.getByLabelText(/gender/i), Patient.GenderEnum.Female);
+    userEvent.selectOptions(screen.getByLabelText(/gender/i), Patient.GenderEnum.Female);
   });
 
   await act(async () => {
@@ -84,7 +84,7 @@ async function setVariantFields() {
     userEvent.click(screen.getByText(/add a variant/i));
   });
   await act(async () => {
-    setDummyAndNext(false, variantDropDowns);
+    await setDummyAndNext(false, variantDropDowns);
   });
 }
 

--- a/src/components/reports/formDataValidation.ts
+++ b/src/components/reports/formDataValidation.ts
@@ -12,7 +12,9 @@ export const patientSchema = Yup.object({
   firstName: requiredString,
   lastName: requiredString,
   dateOfBirth: requiredDate,
-  gender: Yup.mixed<Patient.GenderEnum>().oneOf(Object.values(Patient.GenderEnum)),
+  gender: Yup.mixed<Patient.GenderEnum>()
+    .oneOf(Object.values(Patient.GenderEnum))
+    .test("required", "Please select an option", (value) => value !== undefined),
   familyNumber: requiredString,
 });
 

--- a/src/components/reports/formSteps/Patient.tsx
+++ b/src/components/reports/formSteps/Patient.tsx
@@ -1,4 +1,5 @@
 import { FC, useState } from "react";
+import { Patient as FhirPatient } from "@smile-cdr/fhirts/dist/FHIR-R4/interfaces/IPatient";
 
 import LabSelect from "../../UI/LabSelect";
 import FieldSet from "../FieldSet";
@@ -6,6 +7,10 @@ import FieldSet from "../FieldSet";
 interface Props {
   setFieldValue: (field: string, value: string | string[]) => void;
 }
+
+const genderOptions = Object.values(FhirPatient.GenderEnum).map((value) => {
+  return { code: value, display: value.toString() };
+});
 
 const Patient: FC<Props> = (props) => {
   const [selectedLab, setSelectedLab] = useState("please select a lab");
@@ -45,7 +50,7 @@ const Patient: FC<Props> = (props) => {
       <FieldSet label="First Name" name="patient.lastName" />
       <FieldSet label="Last Name" name="patient.firstName" />
       <FieldSet label="Date of Birth" name="patient.dateOfBirth" type="date" />
-      <FieldSet label="Gender" name="patient.gender" />
+      <FieldSet label="Gender" name="patient.gender" selectOptions={genderOptions} />
       <FieldSet label="Family Number" name="patient.familyNumber" />
     </>
   );


### PR DESCRIPTION
Closes #30 

- Wanted to assign the enum as undefined as an initial value for a blank form, but still ensure that the form always has a defined value
- To do so, kept the field as not required, so type allows undefined, but then validation will ensure that the returned form value is always defined

Currently PR into `loinc_terms` for clarity, will change base branch to `main` after that PR has been merged