### PR TITLE
Use gosh uri for identifiers

### DIFF
--- a/example_data/sampleFHIR_V2.json
+++ b/example_data/sampleFHIR_V2.json
@@ -125,7 +125,8 @@
         },
         "identifier": [
           {
-            "value": "40057119"
+            "value": "40057119",
+            "system": "https://www.gosh.nhs.uk"
           },
           {
             "extension": [
@@ -166,6 +167,7 @@
         "identifier": [
           {
             "value": "20RG-114G00099",
+            "system": "https://www.gosh.nhs.uk",
             "id": "specimen id"
           }
         ],

--- a/src/fhir/resource_helpers.ts
+++ b/src/fhir/resource_helpers.ts
@@ -6,13 +6,33 @@ import {
   ObservationComponent,
   Reference,
 } from "@smile-cdr/fhirts/dist/FHIR-R4/classes/models-r4";
+import { Uri } from "@smile-cdr/fhirts/src/FHIR-R4/classes/uri";
 
 export const reference = (refType: string, id: string): Reference => {
   return { reference: `${refType}/${id}`, type: refType };
 };
 
+type SystemIdentifier = { value: string; system: Uri };
+
 export const makeGoshAssigner = (valueType: string) => {
   return { use: Identifier.UseEnum.Official, assigner: { display: `GOSH ${valueType}` } };
+};
+
+export const goshIdentifier = (value: string, otherFields?: Identifier) => {
+  let usedFields: Identifier = {};
+
+  if (otherFields) {
+    usedFields = otherFields;
+  }
+  return identifier(value, "https://www.gosh.nhs.uk", usedFields);
+};
+
+export const identifier = (value: string, system: Uri, otherFields: Identifier) => {
+  return { ...otherFields, value: value, system: system };
+};
+
+export const getSystemIdentifier = (systemId: SystemIdentifier) => {
+  return `${systemId.system}|${systemId.value}`;
 };
 
 export function generatedNarrative(...parts: string[]) {


### PR DESCRIPTION
Working with ahridia FHIR api and it looks like it looks like to be able to query specifically for a GOSH identifier, we should include a `system` option for them. This can be specified in a FHIR query. e.g. `{{fhirUrl}}/Patient?identifier=https://www.gosh.nhs.uk|969977` 

@EthelEz would you be able to look at the changes to the example bundle and see if that works for you?