### PR TITLE
Form error messages

### DIFF
--- a/example_data/sampleFHIR_V2.json
+++ b/example_data/sampleFHIR_V2.json
@@ -8,7 +8,9 @@
         "resourceType": "DiagnosticReport",
         "id": "a425799a-a905-d750-7e1e-a9c573581a81",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/genomicreport"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/genomicreport"
+          ]
         },
         "status": "final",
         "code": {
@@ -87,7 +89,10 @@
         "name": "Great Ormond Street Hospital for Children NHS Foundation Trust",
         "address": [
           {
-            "line": "Level 4 Barclays House, 37 Queens Square",
+            "line": [
+              "Level 4 Barclays House",
+              "37 Queens Square"
+            ],
             "city": "London",
             "postalCode": "WC1N 3BH",
             "country": "United Kingdom"
@@ -108,7 +113,9 @@
         "name": [
           {
             "family": "Manager",
-            "given": ["General"]
+            "given": [
+              "General"
+            ]
           }
         ],
         "gender": "female",
@@ -191,7 +198,9 @@
           {
             "use": "official",
             "family": "Nephrology",
-            "given": ["Clinics"],
+            "given": [
+              "Clinics"
+            ],
             "text": "Authorized By"
           }
         ],
@@ -223,7 +232,9 @@
           {
             "use": "official",
             "family": "Quality",
-            "given": ["Activity"],
+            "given": [
+              "Activity"
+            ],
             "text": "Reported By"
           }
         ],
@@ -261,7 +272,9 @@
           ]
         },
         "meta": {
-          "profile": ["http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"]
+          "profile": [
+            "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
+          ]
         },
         "subject": {
           "type": "Patient",
@@ -462,7 +475,9 @@
           ]
         },
         "meta": {
-          "profile": ["http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"]
+          "profile": [
+            "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
+          ]
         },
         "subject": {
           "type": "Patient",
@@ -663,7 +678,9 @@
           ]
         },
         "meta": {
-          "profile": ["http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"]
+          "profile": [
+            "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
+          ]
         },
         "subject": {
           "type": "Patient",
@@ -864,7 +881,9 @@
           ]
         },
         "meta": {
-          "profile": ["http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"]
+          "profile": [
+            "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
+          ]
         },
         "subject": {
           "type": "Patient",
@@ -1055,7 +1074,9 @@
         "resourceType": "Task",
         "id": "5f3f5638-3870-1a14-b490-b6081dfc8352",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/task-rec-followup"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/task-rec-followup"
+          ]
         },
         "status": "requested",
         "intent": "plan",
@@ -1086,7 +1107,9 @@
         "id": "6d16ee18-5521-16dd-2ba4-b180cb69ca38",
         "status": "final",
         "meta": {
-          "profile": ["http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/overall-interpretation"]
+          "profile": [
+            "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/overall-interpretation"
+          ]
         },
         "code": {
           "coding": [
@@ -1135,7 +1158,9 @@
         "resourceType": "ServiceRequest",
         "id": "c87a7463-19c1-6a0d-0feb-d845d0dfae43",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/servicerequest"]
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/servicerequest"
+          ]
         },
         "status": "active",
         "intent": "order",

--- a/example_data/sampleFHIR_V2.json
+++ b/example_data/sampleFHIR_V2.json
@@ -8,9 +8,7 @@
         "resourceType": "DiagnosticReport",
         "id": "a425799a-a905-d750-7e1e-a9c573581a81",
         "meta": {
-          "profile": [
-            "http://hl7.org/fhir/StructureDefinition/genomicreport"
-          ]
+          "profile": ["http://hl7.org/fhir/StructureDefinition/genomicreport"]
         },
         "status": "final",
         "code": {
@@ -89,10 +87,7 @@
         "name": "Great Ormond Street Hospital for Children NHS Foundation Trust",
         "address": [
           {
-            "line": [
-              "Level 4 Barclays House",
-              "37 Queens Square"
-            ],
+            "line": "Level 4 Barclays House, 37 Queens Square",
             "city": "London",
             "postalCode": "WC1N 3BH",
             "country": "United Kingdom"
@@ -113,9 +108,7 @@
         "name": [
           {
             "family": "Manager",
-            "given": [
-              "General"
-            ]
+            "given": ["General"]
           }
         ],
         "gender": "female",
@@ -198,9 +191,7 @@
           {
             "use": "official",
             "family": "Nephrology",
-            "given": [
-              "Clinics"
-            ],
+            "given": ["Clinics"],
             "text": "Authorized By"
           }
         ],
@@ -232,9 +223,7 @@
           {
             "use": "official",
             "family": "Quality",
-            "given": [
-              "Activity"
-            ],
+            "given": ["Activity"],
             "text": "Reported By"
           }
         ],
@@ -272,9 +261,7 @@
           ]
         },
         "meta": {
-          "profile": [
-            "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
-          ]
+          "profile": ["http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"]
         },
         "subject": {
           "type": "Patient",
@@ -475,9 +462,7 @@
           ]
         },
         "meta": {
-          "profile": [
-            "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
-          ]
+          "profile": ["http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"]
         },
         "subject": {
           "type": "Patient",
@@ -678,9 +663,7 @@
           ]
         },
         "meta": {
-          "profile": [
-            "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
-          ]
+          "profile": ["http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"]
         },
         "subject": {
           "type": "Patient",
@@ -881,9 +864,7 @@
           ]
         },
         "meta": {
-          "profile": [
-            "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"
-          ]
+          "profile": ["http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant"]
         },
         "subject": {
           "type": "Patient",
@@ -1074,9 +1055,7 @@
         "resourceType": "Task",
         "id": "5f3f5638-3870-1a14-b490-b6081dfc8352",
         "meta": {
-          "profile": [
-            "http://hl7.org/fhir/StructureDefinition/task-rec-followup"
-          ]
+          "profile": ["http://hl7.org/fhir/StructureDefinition/task-rec-followup"]
         },
         "status": "requested",
         "intent": "plan",
@@ -1107,9 +1086,7 @@
         "id": "6d16ee18-5521-16dd-2ba4-b180cb69ca38",
         "status": "final",
         "meta": {
-          "profile": [
-            "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/overall-interpretation"
-          ]
+          "profile": ["http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/overall-interpretation"]
         },
         "code": {
           "coding": [
@@ -1158,9 +1135,7 @@
         "resourceType": "ServiceRequest",
         "id": "c87a7463-19c1-6a0d-0feb-d845d0dfae43",
         "meta": {
-          "profile": [
-            "http://hl7.org/fhir/StructureDefinition/servicerequest"
-          ]
+          "profile": ["http://hl7.org/fhir/StructureDefinition/servicerequest"]
         },
         "status": "active",
         "intent": "order",

--- a/src/components/reports/FormDefaults.ts
+++ b/src/components/reports/FormDefaults.ts
@@ -4,11 +4,8 @@ import { FormValues } from "./ReportForm";
 export const initialValues: FormValues = {
   address: {
     name: "London North Genomic Laboratory Hub",
-    streetAddress: [
-      "Great Ormond Street Hospital for Children NHS Foundation Trust",
-      "Levels 4-6 Barclay House",
-      "37 Queen Square",
-    ],
+    streetAddress:
+      "Great Ormond Street Hospital for Children NHS Foundation Trust, Levels 4-6 Barclay House, 37 Queen Square",
     city: "London",
     country: "UK",
     postCode: "WC1N 3BH",
@@ -86,7 +83,7 @@ export const initialWithNoVariant = {
 export const noValues: FormValues = {
   address: {
     name: "",
-    streetAddress: [],
+    streetAddress: "",
     city: "",
     country: "",
     postCode: "",

--- a/src/components/reports/formDataValidation.ts
+++ b/src/components/reports/formDataValidation.ts
@@ -4,7 +4,7 @@ import { parseDateTime, today } from "../../utils/dateTime";
 import moment from "moment";
 
 const optionalString = Yup.string().optional();
-const requiredString = Yup.string().required();
+const requiredString = Yup.string().required("This is a required field");
 
 const date = Yup.string()
   .test("valid-date", "Please enter a valid date", (value) => value === undefined || moment(value).isValid())
@@ -13,7 +13,7 @@ const date = Yup.string()
     "Please enter a valid date in the past",
     (value) => value === undefined || moment(value).isBefore(today),
   );
-export const requiredDate = date.required();
+export const requiredDate = date.required("This is a required field");
 
 export const dateTime = Yup.string()
   .test("valid-date", "Please enter a valid date in DD/MM/YYYY or date time in DD/MM/YYYY HH:mm (24 hour)", (value) => {
@@ -50,7 +50,7 @@ export type PatientSchema = Yup.InferType<typeof patientSchema>;
 
 export const addressSchema = Yup.object({
   name: requiredString,
-  streetAddress: Yup.array().of(Yup.string().required()).required(),
+  streetAddress: requiredString,
   city: requiredString,
   postCode: requiredString,
   country: requiredString,

--- a/src/components/reports/formSteps/Patient.tsx
+++ b/src/components/reports/formSteps/Patient.tsx
@@ -5,7 +5,7 @@ import LabSelect from "../../UI/LabSelect";
 import FieldSet from "../FieldSet";
 
 interface Props {
-  setFieldValue: (field: string, value: string | string[]) => void;
+  setFieldValue: (field: string, value: string) => void;
 }
 
 const genderOptions = Object.values(FhirPatient.GenderEnum).map((value) => {
@@ -20,11 +20,10 @@ const Patient: FC<Props> = (props) => {
   const setSelectedLabHandler = (lab: string) => {
     if (lab === "gosh") {
       setFieldValue("address.name", "London North Genomic Laboratory Hub");
-      setFieldValue("address.streetAddress", [
-        "Great Ormond Street Hospital for Children NHS Foundation Trust",
-        "Levels 4-6 Barclay House",
-        "37 Queen Square",
-      ]);
+      setFieldValue(
+        "address.streetAddress",
+        "Great Ormond Street Hospital for Children NHS Foundation Trust, Levels 4-6 Barclay House, 37 Queen Square",
+      );
       setFieldValue("address.city", "London");
       setFieldValue("address.postCode", "WC1N 3BH");
       setFieldValue("address.country", "UK");

--- a/src/fhir/resources.ts
+++ b/src/fhir/resources.ts
@@ -84,6 +84,7 @@ export const patientAndId = (form: PatientSchema, organisationId: string): Resou
 };
 
 export const organisationAndId = (form: AddressSchema): ResourceAndIds => {
+  console.log(form);
   const org = new Organization();
   org.id = uuidv4();
   org.identifier = [{ value: GOSH_GENETICS_IDENTIFIER }];
@@ -105,7 +106,7 @@ export const organisationAndId = (form: AddressSchema): ResourceAndIds => {
   org.name = form.name;
   org.address = [
     {
-      line: form.streetAddress,
+      line: [form.streetAddress],
       city: form.city,
       postalCode: form.postCode,
       country: form.country,

--- a/src/fhir/resources.ts
+++ b/src/fhir/resources.ts
@@ -84,7 +84,6 @@ export const patientAndId = (form: PatientSchema, organisationId: string): Resou
 };
 
 export const organisationAndId = (form: AddressSchema): ResourceAndIds => {
-  console.log(form);
   const org = new Organization();
   org.id = uuidv4();
   org.identifier = [{ value: GOSH_GENETICS_IDENTIFIER }];

--- a/src/fhir/resources.ts
+++ b/src/fhir/resources.ts
@@ -105,7 +105,7 @@ export const organisationAndId = (form: AddressSchema): ResourceAndIds => {
   org.name = form.name;
   org.address = [
     {
-      line: [form.streetAddress],
+      line: [form.streetAddress], // array type to conform with FHIR requirements
       city: form.city,
       postalCode: form.postCode,
       country: form.country,

--- a/src/fhir/resources.ts
+++ b/src/fhir/resources.ts
@@ -105,7 +105,7 @@ export const organisationAndId = (form: AddressSchema): ResourceAndIds => {
   org.name = form.name;
   org.address = [
     {
-      line: [form.streetAddress], // array type to conform with FHIR requirements
+      line: form["streetAddress"].split(","), // split the string to maintain Array type and conform with FHIR schema
       city: form.city,
       postalCode: form.postCode,
       country: form.country,


### PR DESCRIPTION
- Added user friendly error messages to form fields. The specific error messages can be changed if desired.
- Changed the `streetAddress` field from `string[]` to `string`. To avoid type errors, line 108 in `resources.ts` is still of type `Array`. There may be a better solution for this depending on the requirements from FHIR.
- Updated some example form field defaults to conform with the above `string[]` to `string` change.