### PR TITLE
Github deployment in actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,10 @@
 name: Deploy to github pages
 
 on:
-  # only try to run when test actions have completed on main or deploy_github for testing
+  # only try to run when test actions have completed on main
   workflow_run:
     workflows: [ "Tests" ]
-    branches: [ main, deploy_github ]
+    branches: [ main ]
     types:
       - completed
 
@@ -25,8 +25,11 @@ jobs:
       - name: Install dependencies
         run: |
           npm ci
-      - name: Setup mock git user
-        run: |
-          git config --global user.email "gmsa@fhir.com"
-          git config --global user.name "Unused account"
-      - run: npm run deploy
+      - run: npm run predeploy
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build
+          # disabling jekyll seems to stop environmental variables from being read by react
+          enable_jekyll: true

--- a/src/components/fhir/FhirAuthoriser.tsx
+++ b/src/components/fhir/FhirAuthoriser.tsx
@@ -2,8 +2,7 @@ import { FC, useEffect, useState } from "react";
 import { oauth2 as SMART } from "fhirclient";
 
 import LoadingSpinner from "../UI/LoadingSpinner";
-import ModalWrapper from "../UI/ModalWrapper";
-import { ModalState } from "../UI/ModalWrapper";
+import ModalWrapper, { ModalState } from "../UI/ModalWrapper";
 
 const FHIR_URL = process.env.REACT_APP_FHIR_URL;
 const CLIENT_ID = process.env.REACT_APP_CLIENT_ID;
@@ -32,7 +31,7 @@ const FhirAuthoriser: FC = () => {
       .catch((error) => {
         console.log(error);
         setModal({
-          message: "Something went wrong connecting to the FHIR authoriser. Please try again later.",
+          message: "Something went wrong connecting to the FHIR server.",
           isError: true,
         });
       })


### PR DESCRIPTION
Had some fun with this, it appears the jekyll out the jekyll deployment is required for the environmental variables to be read within the react app. Also made a change to the modal message because a deployment will be skipped if there aren't any changes 