### PR TITLE
Specify that github deployment will only connect to localhost

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,6 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: github-pages
     # only run steps if the workflow didn't fail
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
@@ -25,6 +24,8 @@ jobs:
       - name: Install dependencies
         run: |
           npm ci
+      - name: Setup .env file
+        run: cp env/dev.env .env
       - run: npm run predeploy
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 Prototype for FHIR genomics reports.
 
 > **Note**
-> If you have a Great Ormond St. Hospital account and have been granted access to the
-> Aridhia synthetic FHIR server you can view the current version of the application on
-> [the GitHub.io page](https://gosh-dre.github.io/gmsa_genomic_fhir_webapp/#/).
+> If you have cloned and run the docker commands in the [Development services section](#development-services) then  
+> [the GitHub.io page](https://gosh-dre.github.io/gmsa_genomic_fhir_webapp/#/) will connect to your FHIR server
+> that is running on your machine.
 
 > **Warning**
 > This is only for testing, and no clinical data should be entered


### PR DESCRIPTION
It never connected to the fhir server as environmental variables are masked from deployments. This way we are using the env file and the default localhost development can be run 