### PR TITLE
Update testing to allow for modal test

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,29 +1,12 @@
 version: "3.7"
 services:
   fhir:
-    image: "hapiproject/hapi:v5.6.0"
+    image: "hapiproject/hapi:v6.1.0"
     ports:
       - "8090:8080"
     environment:
-      spring.datasource.url: "jdbc:postgresql://fhir-db:5432/hapi_r4"
-      spring.datasource.username: admin
-      spring.datasource.password: admin
-      spring.datasource.driverClassName: org.postgresql.Driver
-      hapi.fhir.subscription.resthook_enabled: "true"
-      hapi.fhir.subscription.websocket_enabled: "true"
       hapi.fhir.client_id_strategy: ANY
       hapi.fhir.cors.allowed_origin: "*"
       hapi.fhir.fhir_version: R4
       hapi.fhir.allow_cascading_deletes: "true"
       hapi.fhir.reuse_cached_search_results_millis: -1
-  fhir-db:
-    image: postgres:latest
-    volumes:
-      - fhir-db-data:/var/lib/postgresql/data
-    environment:
-      POSTGRES_PASSWORD: admin
-      POSTGRES_USER: admin
-      POSTGRES_DB: hapi_r4
-
-volumes:
-  fhir-db-data:

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "build": "react-scripts build",
     "predeploy": "react-scripts build && cp build/index.html build/404.html",
     "deploy": "COMMIT_MSG=$(git log -1 --pretty=%B | sed  's/ /_/g'); gh-pages -d build --message ${COMMIT_MSG}",
-    "test": "react-scripts test",
+    "test": "react-scripts test --runInBand",
     "eject": "react-scripts eject",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },

--- a/src/components/reports/ReportForm.test.tsx
+++ b/src/components/reports/ReportForm.test.tsx
@@ -1,10 +1,8 @@
-import ReportForm from "./ReportForm";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Patient } from "@smile-cdr/fhirts/dist/FHIR-R4/classes/patient";
-import { initialWithNoVariant, noValues } from "./FormDefaults";
 import { act } from "react-dom/test-utils";
-import { createPractitioner, deleteFhirData } from "../../fhir/testUtilities";
+import { createPractitioner, deleteFhirData, TestReportForm } from "../../fhir/testUtilities";
 import { Practitioner } from "@smile-cdr/fhirts/dist/FHIR-R4/classes/practitioner";
 import { createIdentifier } from "../../fhir/resource_helpers";
 
@@ -19,7 +17,7 @@ type DropDown = {
 };
 
 const setDummyValues = (withDates: boolean, dropDowns?: DropDown[]) => {
-  const dummyValue = "Always the same";
+  const dummyValue = "Always_the_same";
   const form = screen.getByRole("form");
   const textInputs = within(form).getAllByLabelText(
     /^((?!resultOutput|date|address|gender|specimen type|search|gene symbol|follow up).)*$/i,
@@ -146,10 +144,9 @@ describe("Report form", () => {
 
   test("Error modal exists", async () => {
     // Arrange
-    render(<ReportForm initialValues={initialWithNoVariant} />);
     const practitioner = new Practitioner();
     practitioner.resourceType = "Practitioner";
-    const identifier = createIdentifier("anapietra_report");
+    const identifier = createIdentifier("always_the_same_report");
     practitioner.identifier = [identifier];
     console.log(practitioner);
 
@@ -157,6 +154,7 @@ describe("Report form", () => {
     createPractitioner(practitioner);
 
     // Act
+    render(<TestReportForm />);
     await setLabAndPatient();
     await setSample();
     await setVariantFields();
@@ -176,7 +174,7 @@ describe("Report form", () => {
    */
   test("Report with variant", async () => {
     // Arrange
-    render(<ReportForm initialValues={noValues} />);
+    render(<TestReportForm />);
 
     // Act
     await setLabAndPatient();
@@ -199,7 +197,7 @@ describe("Report form", () => {
    */
   test("Report without variant", async () => {
     // Arrange
-    render(<ReportForm initialValues={noValues} />);
+    render(<TestReportForm />);
 
     // Act
     await setLabAndPatient();

--- a/src/fhir/api.test.ts
+++ b/src/fhir/api.test.ts
@@ -6,7 +6,7 @@ import { geneCoding } from "../code_systems/hgnc";
 import { Bundle } from "@smile-cdr/fhirts/dist/FHIR-R4/classes/bundle";
 import { BundleEntry } from "@smile-cdr/fhirts/dist/FHIR-R4/classes/bundleEntry";
 import { Patient } from "@smile-cdr/fhirts/dist/FHIR-R4/classes/models-r4";
-import { sendBundle, checkResponseOK, deleteFhirData, getResources } from "./testUtilities";
+import { deleteFhirData, getResources, sendBundle } from "./testUtilities";
 
 const fhir = new Fhir();
 
@@ -32,9 +32,8 @@ const getPatientGivenNames = (patientData: Bundle) => {
 };
 
 describe("FHIR resources", () => {
-  beforeEach(async () => {
-    await deleteFhirData();
-    await new Promise((r) => setTimeout(r, 1500));
+  beforeEach(() => {
+    return deleteFhirData();
   });
 
   /**
@@ -56,7 +55,6 @@ describe("FHIR resources", () => {
     const createPatient = await sendBundle(bundle);
 
     // check it's the right patient
-    await checkResponseOK(createPatient);
     const patientData = await getResources("Patient");
     expect("entry" in patientData).toBeTruthy();
     expect(getPatientIdentifier(patientData)).toEqual(initialValues.patient.mrn);


### PR DESCRIPTION
- went for slimming down the dev FHIR server to only minimal required, as we're not using this in production
- found the source of why tests were flaky! - turns out by default tests are ran in parallel, might be worth looking in the jest documentation to see if there's a way to mark individual tests as having to be run sequentially, otherwise using the command line flag that I've set for `npm test` should work
- Updated some of the test setup so that the modal should then be able to work during testing. Might be worth experimenting to see if we need to have any timeout at all now that we're not running tests in parallel 