### PR TITLE
Ensure list view uses FH results

### DIFF
--- a/src/components/reports/ReportForm.test.tsx
+++ b/src/components/reports/ReportForm.test.tsx
@@ -165,6 +165,17 @@ const renderTestReportForm = () => {
   render(<ContextAndModal children={<ReportForm initialValues={noValues} />} />, { wrapper: BrowserRouter });
 };
 
+beforeAll(() => {
+  /*
+   * For some reason on first load of FHIR server, creating a batch of requests doesn't seem to validate
+   * Sending a resource before any test are run fixed the issue
+   */
+  const practitioner = new Practitioner();
+  practitioner.resourceType = "Practitioner";
+  practitioner.identifier = [createIdentifier("initial")];
+  return createPractitioner(practitioner);
+});
+
 describe("Report form", () => {
   beforeEach(() => {
     return deleteFhirData();

--- a/src/components/results-list/ResultsDataFetcher.test.tsx
+++ b/src/components/results-list/ResultsDataFetcher.test.tsx
@@ -123,11 +123,11 @@ const changePatientInfo = (valuesToUpdate: OverridingFields) => {
   return newPatient;
 };
 
-describe("Results table", () => {
-  beforeEach(() => {
-    return clearFhirAndSendReports();
-  });
+beforeAll(() => {
+  return clearFhirAndSendReports();
+});
 
+describe("Results table", () => {
   /**
    * Given the FHIR API is cleared and has 6 separate reports added with one variant each (one not FH)
    * When the Results list page is rendered

--- a/src/components/results-list/ResultsDataFetcher.test.tsx
+++ b/src/components/results-list/ResultsDataFetcher.test.tsx
@@ -139,10 +139,13 @@ describe("Results table", () => {
     render(<ContextAndModal children={<ResultsDataFetcher />} />);
 
     // Can put a breakpoint here to allow for development with 5 patients added to the result list
-    await waitFor(() => {
-      const resultsTable = screen.getAllByText(/NM_/);
-      expect(resultsTable.length).toEqual(5);
-    });
+    await waitFor(
+      () => {
+        const resultsTable = screen.getAllByText(/NM_/);
+        expect(resultsTable.length).toEqual(5);
+      },
+      { timeout: 15000 },
+    );
   });
 });
 
@@ -159,9 +162,12 @@ describe("Modal from results table", () => {
   };
 
   const textIsInDocument = async (regExp: RegExp) => {
-    await waitFor(() => {
-      expect(screen.queryByText(regExp)).toBeInTheDocument();
-    });
+    await waitFor(
+      () => {
+        expect(screen.queryByText(regExp)).toBeInTheDocument();
+      },
+      { timeout: 15000 },
+    );
   };
 
   /**

--- a/src/components/results-list/ResultsDataFetcher.test.tsx
+++ b/src/components/results-list/ResultsDataFetcher.test.tsx
@@ -15,7 +15,7 @@ type OverridingFields = {
     nhsNumber: string;
     firstName: string;
     lastName: string;
-    familyNumber: string;
+    familyNumber?: string;
   };
   sample: {
     specimenCode: string;
@@ -31,14 +31,17 @@ const clearFhirAndSendReports = async () => {
   await deleteFhirData();
 
   const overridingValues = [
-    // not FH
-    createPatientOverrides("Daffy", "Duck", ["R59"], "HGNC:4389", "c.115A>T"),
+    // not FH so shouldn't be in the list
+    createPatientOverrides("Daffy", "Duck", ["R59"], "HGNC:4389", "c.140G>A"),
     // Has a family member who has been tests
-    createPatientOverrides("Bugs", "Bunny", ["R134"], "HGNC:6547", "c.113A>T", "F12345"),
-    createPatientOverrides("Betty", "Bunny", ["R134"], "HGNC:6547", "c.113A>T", "F12345"),
+    createPatientOverrides("Bugs", "Bunny", ["R134"], "HGNC:6547", "NM_000527.5:c.259T>G", "F12345"),
+    createPatientOverrides("Betty", "Bunny", ["R134"], "HGNC:6547", "NM_000527.5:c.259T>G", "F12345"),
     // No family member who has been tested
-    createPatientOverrides("Road", "Runner", ["R134"], "HGNC:6547", "c.110A>T", "F10000"),
-    createPatientOverrides("Wile", "Coyote", ["R134"], "HGNC:6547", "c.112A>T"),
+    createPatientOverrides("Road", "Runner", ["R134"], "HGNC:6547", "NM_000527.5:c.27C>T", "F10000"),
+    // No family member
+    createPatientOverrides("Wile", "Coyote", ["R134"], "HGNC:6547", "NM_000527.5:c.58G>A"),
+    // Benign
+    createPatientOverrides("Yosemite", "Sam", ["R134"], "HGNC:6547", "NM_000527.5:c.9C>T"),
   ];
 
   for (const override of overridingValues) {
@@ -58,13 +61,13 @@ const createPatientOverrides = (
 ): OverridingFields => {
   return {
     patient: {
-      mrn: generateNumber("mrn"),
-      nhsNumber: generateNumber("nhs"),
+      mrn: generateId("mrn"),
+      nhsNumber: generateId("nhs"),
       firstName: firstName,
       lastName: lastName,
-      familyNumber: familyNumber ? familyNumber : generateNumber("family"),
+      familyNumber: familyNumber,
     },
-    sample: { specimenCode: generateNumber("specimen"), reasonForTest: testReason },
+    sample: { specimenCode: generateId("specimen"), reasonForTest: testReason },
     variant: {
       cDnaHgvs: cDnaHgvs,
       gene: gene,
@@ -72,15 +75,13 @@ const createPatientOverrides = (
   };
 };
 
-const generateNumber = (type?: "nhs" | "family" | "specimen" | "mrn") => {
+const generateId = (type?: "nhs" | "specimen" | "mrn") => {
   let num;
   const characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
   const randomCharacter = characters[Math.floor(Math.random() * characters.length)];
 
   if (type === "nhs") {
     num = Math.floor(Math.random() * Math.pow(10, 10));
-  } else if (type === "family") {
-    num = randomCharacter + Math.floor(Math.random() * Math.pow(10, 6));
   } else if (type === "specimen") {
     num = randomCharacter + Math.floor(Math.random() * Math.pow(10, 10));
   } else if (type === "mrn") {

--- a/src/components/results-list/ResultsDataFetcher.test.tsx
+++ b/src/components/results-list/ResultsDataFetcher.test.tsx
@@ -111,9 +111,9 @@ describe("Results table", () => {
   });
 
   /**
-   * Given the FHIR API is cleared and has 5 separate reports added with one variant
+   * Given the FHIR API is cleared and has 5 separate reports added with one variant each (one not FH)
    * When the Results list page is rendered
-   * Then there should be 5 variants listed
+   * Then there should be 4 FH variants listed
    */
   test("patients are in table", async () => {
     render(<ContextAndModal children={<ResultsDataFetcher />} />);

--- a/src/components/results-list/ResultsDataFetcher.tsx
+++ b/src/components/results-list/ResultsDataFetcher.tsx
@@ -158,7 +158,8 @@ const ResultsDataFetcher: FC = () => {
 
   let resultsComponent = <></>;
   if (parsedResults) {
-    resultsComponent = <ResultsList results={parsedResults} />;
+    const sortedResults = parsedResults.sort((a, b) => a.lastName.localeCompare(b.lastName));
+    resultsComponent = <ResultsList results={sortedResults} />;
   }
   return (
     <>

--- a/src/components/results-list/ResultsDataFetcher.tsx
+++ b/src/components/results-list/ResultsDataFetcher.tsx
@@ -42,7 +42,7 @@ const ResultsDataFetcher: FC = () => {
   const [parsedResults, setParsedResults] = useState<ParsedResultsModel | null>(null);
 
   useEffect(() => {
-    const observationQueryUrl = `DiagnosticReport/?_include=DiagnosticReport:result&_include=DiagnosticReport:subject`;
+    const observationQueryUrl = `DiagnosticReport/?code=${FH_CODE}&_include=DiagnosticReport:result&_include=DiagnosticReport:subject`;
 
     setIsLoading(true);
 

--- a/src/components/results-list/ResultsDataFetcher.tsx
+++ b/src/components/results-list/ResultsDataFetcher.tsx
@@ -153,7 +153,7 @@ const ResultsDataFetcher: FC = () => {
   };
 
   if (!parsedResults && !isLoading) {
-    return <div>Familial hypercholesterolemia patient results were found on the FHIR server</div>;
+    return <div>No familial hypercholesterolemia patient results were found on the FHIR server</div>;
   }
 
   let resultsComponent = <></>;

--- a/src/components/results-list/ResultsDataFetcher.tsx
+++ b/src/components/results-list/ResultsDataFetcher.tsx
@@ -153,7 +153,7 @@ const ResultsDataFetcher: FC = () => {
   };
 
   if (!parsedResults && !isLoading) {
-    return <div>Something went wrong getting observations. Please try again later.</div>;
+    return <div>Familial hypercholesterolemia patient results were found on the FHIR server</div>;
   }
 
   let resultsComponent = <></>;

--- a/src/components/results-list/ResultsList.tsx
+++ b/src/components/results-list/ResultsList.tsx
@@ -75,7 +75,7 @@ const ResultsList: FC<Props> = (props) => {
       <ModalWrapper isError={modal?.isError} modalMessage={modal?.message} onClear={() => setModal(null)} />
       {isLoading && <LoadingSpinner asOverlay message={"Getting observations..."} />}
 
-      <h1>Patient results table</h1>
+      <h1>Familial hypercholesterolemia patient results</h1>
 
       <table className={classes["results-table"]}>
         <thead>

--- a/src/components/results-list/ResultsList.tsx
+++ b/src/components/results-list/ResultsList.tsx
@@ -1,10 +1,9 @@
-import { FC, useState, useContext } from "react";
+import { FC, useContext, useState } from "react";
 import { FhirContext } from "../fhir/FhirContext";
 import { Patient } from "@smile-cdr/fhirts/dist/FHIR-R4/classes/models-r4";
 
 import LoadingSpinner from "../UI/LoadingSpinner";
-import ModalWrapper from "../UI/ModalWrapper";
-import { ModalState } from "../UI/ModalWrapper";
+import ModalWrapper, { ModalState } from "../UI/ModalWrapper";
 
 import { ParsedResultsModel, TrimmedObservation } from "./ResultsDataFetcher";
 
@@ -84,6 +83,7 @@ const ResultsList: FC<Props> = (props) => {
             <th>First name</th>
             <th>Last name</th>
             <th>cDNA changes</th>
+            <th>Overall interpretation</th>
           </tr>
         </thead>
         <tbody>
@@ -107,6 +107,7 @@ const ResultsList: FC<Props> = (props) => {
                     );
                   })}
                 </td>
+                <td>{patient.overallInterpretation}</td>
               </tr>
             );
           })}

--- a/src/components/results-list/ResultsList.tsx
+++ b/src/components/results-list/ResultsList.tsx
@@ -57,11 +57,12 @@ const ResultsList: FC<Props> = (props) => {
   };
 
   const displayCascadeAdvice = (patients: Patient[], overallInterpretation: string) => {
-    if (overallInterpretation === "Positive") {
+    if (overallInterpretation !== "Positive") {
       setModal({
         message: `Patient has no pathogenic variants reported`,
         isError: false,
       });
+      return;
     }
 
     if (patients.length === 1) {
@@ -95,7 +96,7 @@ const ResultsList: FC<Props> = (props) => {
           <tr>
             <th>First name</th>
             <th>Last name</th>
-            <th>cDNA changes</th>
+            <th>cDNA change(s)</th>
             <th>Overall interpretation</th>
           </tr>
         </thead>

--- a/src/fhir/api.ts
+++ b/src/fhir/api.ts
@@ -86,7 +86,7 @@ export const createBundle = (form: FormValues, reportedGenes: RequiredCoding[]):
     reporter.identifier,
     authoriser.identifier,
     org.identifier,
-    variants.map((variant) => variant.identifier),
+    [overallInterpretation.identifier, ...variants.map((variant) => variant.identifier)],
     reportIdentifier,
   );
   return {

--- a/src/fhir/testUtilities.tsx
+++ b/src/fhir/testUtilities.tsx
@@ -20,7 +20,6 @@ export const createPractitioner = async (practitioner: Practitioner) => {
       "Content-Type": "application/json",
     },
   });
-  // await new Promise((r) => setTimeout(r, 500));
   return checkResponseOK(sendPractitioner);
 };
 

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -2,12 +2,9 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import { Practitioner } from "@smile-cdr/fhirts/dist/FHIR-R4/classes/practitioner";
 import "@testing-library/jest-dom";
 
 import { enableFetchMocks } from "jest-fetch-mock";
-import { createIdentifier } from "./fhir/resource_helpers";
-import { createPractitioner } from "./fhir/testUtilities";
 
 jest.resetAllMocks();
 /**
@@ -19,20 +16,8 @@ jest.mock("react-router-dom", () => ({
   useNavigate: () => mockedNavigate,
 }));
 
-beforeAll(async () => {
-  /*
-   * For some reason on first load of FHIR server, creating a batch of requests doesn't seem to validate
-   * Sending a resource before any test are run fixed the issue
-   */
-  const practitioner = new Practitioner();
-  practitioner.resourceType = "Practitioner";
-  practitioner.identifier = [createIdentifier("initial")];
-  await createPractitioner(practitioner);
-
+beforeEach(() => {
   enableFetchMocks();
-});
-
-global.beforeEach(() => {
   fetchMock.resetMocks();
   fetchMock.mockIf(/clinicaltables\.nlm\.nih\.gov\/api\/genes\/v4\/search/, (request: Request) => {
     let requestData: (number | string[] | string[][] | null)[] = [0, [], null, []];


### PR DESCRIPTION
We're now implementing the results list for FH patients and using the new structure of the FHIR bundle 🎉 

closes #63 

- Results lists show FH reports only
- Results lists shows overall interpretation
- Specific modal for (and tests):
  - positive result and other family members tested
  - positive result and no other famliy members tested
  - negative result
  - postitive result and no family number for patient
-  Also rationalised the setup of tests so that we're not repeating FHIR requests that aren't needed 
- Ensured loading spinner is shown while results are fetched for list view